### PR TITLE
Add block menu entry

### DIFF
--- a/R/g6r.R
+++ b/R/g6r.R
@@ -36,7 +36,25 @@ set_g6_options <- function(graph, ...) {
             return d.label
           }"
         )
-      )
+      ),
+      palette = list(
+        type = "group",
+        field = "cluster"
+      ),
+      state = JS("{
+        selected: {
+          keyShape: {
+            stroke: '#2D3748',
+            lineWidth: 3
+          }
+        },
+        active: {
+          keyShape: {
+            stroke: '#6B7280',
+            lineWidth: 2
+          }
+        }
+      }")
     ),
     combo = list(
       animation = FALSE,
@@ -171,7 +189,23 @@ set_g6_plugins <- function(graph, ..., ns, path, ctx) {
               }
             );
             const items = await response.json();
-            return items;
+
+            // Separate primary actions from others and put them at top
+            // This reduces mouse travel distance after right-click
+            const primaryItems = [];
+            const otherItems = [];
+
+            items.forEach(item => {
+              // Match by name since value property doesn't exist
+              if (item.name && (item.name.includes('Add block') || item.name.includes('Append block'))) {
+                primaryItems.push(item);
+              } else {
+                otherItems.push(item);
+              }
+            });
+
+            // Primary actions first, then separator, then other items
+            return [...primaryItems, ...otherItems];
           }",
           path
         )

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,6 +1,17 @@
 dag_ext_ui <- function(id, board) {
   ns <- shiny::NS(id)
   tagList(
+    context_menu_dep(),
     g6_output(graph_id(ns), height = "100vh")
+  )
+}
+
+context_menu_dep <- function() {
+  htmltools::htmlDependency(
+    name = "blockr-dag-context-menu",
+    version = utils::packageVersion("blockr.dag"),
+    src = system.file("assets", package = "blockr.dag"),
+    script = "js/context-menu.js",
+    all_files = FALSE
   )
 }

--- a/inst/assets/js/context-menu.js
+++ b/inst/assets/js/context-menu.js
@@ -1,0 +1,86 @@
+// Context Menu Enhancement for blockr.dag
+// This script adds styling to primary G6 context menu items
+
+// Function to style primary action menu items
+function stylePrimaryMenuItems() {
+  // Look for all possible context menu containers
+  const menus = document.querySelectorAll('[class*="context-menu"], [class*="contextmenu"]');
+
+  menus.forEach(menu => {
+    // Find all menu items (try different possible selectors)
+    const items = menu.querySelectorAll('li, [class*="item"], [role="menuitem"]');
+
+    items.forEach(item => {
+      const text = item.textContent || '';
+
+      // Check if this is a primary action (Append block or Add block)
+      // Note: G6 context menu items don't have data-value attributes, so we match by text
+      if (text.includes('Append block') || text.includes('Add block')) {
+
+        // Apply subtle background with separator
+        item.style.cssText = `
+          background: #f8f9fa !important;
+          color: #212529 !important;
+          font-weight: 500 !important;
+          padding: 10px 16px !important;
+          margin-left: 0 !important;
+          margin-right: 0 !important;
+          margin-bottom: 8px !important;
+          padding-bottom: 12px !important;
+          border-bottom: 1px solid #dee2e6 !important;
+          transition: background-color 0.15s ease !important;
+        `;
+
+        // Add subtle hover effect
+        item.addEventListener('mouseenter', function() {
+          this.style.backgroundColor = '#e9ecef';
+        });
+
+        item.addEventListener('mouseleave', function() {
+          this.style.backgroundColor = '#f8f9fa';
+        });
+
+        // Only add the icon if it's not already there (check for ➕)
+        if (!text.includes('➕')) {
+          item.innerHTML = '<span style="color: #198754; font-size: 1.3em; margin-right: 8px; vertical-align: middle;">➕</span>' +
+                          '<span style="vertical-align: middle;">' + text + '</span>';
+        }
+      }
+    });
+  });
+}
+
+// Use MutationObserver to detect when context menus are added to the DOM
+const observer = new MutationObserver(function(mutations) {
+  mutations.forEach(function(mutation) {
+    mutation.addedNodes.forEach(function(node) {
+      if (node.nodeType === 1) { // Element node
+        // Check if this node or its children contain a context menu
+        if (node.matches && (node.matches('[class*="context-menu"]') ||
+            node.matches('[class*="contextmenu"]'))) {
+          setTimeout(stylePrimaryMenuItems, 10);
+        } else if (node.querySelector) {
+          const hasMenu = node.querySelector('[class*="context-menu"], [class*="contextmenu"]');
+          if (hasMenu) {
+            setTimeout(stylePrimaryMenuItems, 10);
+          }
+        }
+      }
+    });
+  });
+});
+
+// Start observing the document for DOM changes
+if (document.body) {
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true
+  });
+} else {
+  document.addEventListener('DOMContentLoaded', function() {
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  });
+}

--- a/inst/assets/js/context-menu.js
+++ b/inst/assets/js/context-menu.js
@@ -41,9 +41,13 @@ function stylePrimaryMenuItems() {
         });
 
         // Only add the icon if it's not already there (check for ➕)
-        if (!text.includes('➕')) {
-          item.innerHTML = '<span style="color: #198754; font-size: 1.3em; margin-right: 8px; vertical-align: middle;">➕</span>' +
-                          '<span style="vertical-align: middle;">' + text + '</span>';
+        // Use CSS ::before pseudo-element instead of modifying innerHTML to avoid breaking G6's click handlers
+        if (!item.querySelector('.menu-icon-prefix')) {
+          const iconSpan = document.createElement('span');
+          iconSpan.className = 'menu-icon-prefix';
+          iconSpan.style.cssText = 'color: #198754; font-size: 1.3em; margin-right: 8px; vertical-align: middle;';
+          iconSpan.textContent = '➕';
+          item.insertBefore(iconSpan, item.firstChild);
         }
       }
     });


### PR DESCRIPTION
Another style idea: A more prominent an unify 'Add Block' menu entry would make it easier to quickly generate workflows.

Just a PoC, not meant to be merged.

<img width="430" height="500" alt="image" src="https://github.com/user-attachments/assets/f77c05b8-9a5f-4ad6-883f-b31c0a966b52" />
