### PR TITLE
light color dag

### DIFF
--- a/R/modal.R
+++ b/R/modal.R
@@ -161,20 +161,42 @@ css_block_selectize <- function() {
 
 #' Shared JavaScript rendering functions for block selectize
 #'
+#' @param icon_style Icon style setting: "light" or "solid"
 #' @return JavaScript string with item and option render functions
 #' @keywords internal
-js_blk_selectize_render <- function() {
+js_blk_selectize_render <- function(icon_style = "light") {
   I(
-    "{
+    sprintf(
+      "(function() {
+      var iconStyle = '%s';
+      return {
       item: function(item, escape) {
+        var hexToRgba = function(hex, alpha) {
+          var r = parseInt(hex.slice(1, 3), 16);
+          var g = parseInt(hex.slice(3, 5), 16);
+          var b = parseInt(hex.slice(5, 7), 16);
+          return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+        };
+
         var name = escape(item.label);
         var pkg = escape(item.package || '');
         var color = item.color || '#6c757d';
 
         var iconSvg = item.icon || '';
+
+        // Configure based on icon style
+        var iconFill, bgColor;
+        if (iconStyle === 'light') {
+          iconFill = color;
+          bgColor = hexToRgba(color, 0.3);
+        } else {
+          iconFill = 'white';
+          bgColor = color;
+        }
+
         var styledSvg = iconSvg.replace(
           '<svg ',
-          '<svg style=\"width: 14px; height: 14px; fill: white;\" '
+          '<svg style=\"width: 14px; height: 14px; fill: ' + iconFill + ';\" '
         );
 
         var containerStyle =
@@ -182,7 +204,7 @@ js_blk_selectize_render <- function() {
           'padding: 4px 8px; background-color: #f8f9fa; ' +
           'border-radius: 6px; border: 1px solid #e9ecef;';
         var iconStyle =
-          'background-color: ' + color + '; width: 24px; ' +
+          'background-color: ' + bgColor + '; width: 24px; ' +
           'height: 24px; border-radius: 4px; display: flex; ' +
           'align-items: center; justify-content: center; flex-shrink: 0;';
         var pkgBadgeHtml = pkg ?
@@ -194,18 +216,36 @@ js_blk_selectize_render <- function() {
                name + '</div>' + pkgBadgeHtml + '</div>';
       },
       option: function(item, escape) {
+        var hexToRgba = function(hex, alpha) {
+          var r = parseInt(hex.slice(1, 3), 16);
+          var g = parseInt(hex.slice(3, 5), 16);
+          var b = parseInt(hex.slice(5, 7), 16);
+          return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+        };
+
         var name = escape(item.label);
         var desc = escape(item.description || '');
         var pkg = escape(item.package || '');
         var color = item.color || '#6c757d';
 
         var iconSvg = item.icon || '';
+
+        // Configure based on icon style
+        var iconFill, bgColor;
+        if (iconStyle === 'light') {
+          iconFill = color;
+          bgColor = hexToRgba(color, 0.3);
+        } else {
+          iconFill = 'white';
+          bgColor = color;
+        }
+
         var styledSvg = iconSvg.replace(
           '<svg ',
-          '<svg style=\"width: 20px; height: 20px; fill: white;\" '
+          '<svg style=\"width: 20px; height: 20px; fill: ' + iconFill + ';\" '
         );
 
-        var iconWrapperStyle = 'background-color: ' + color + ';';
+        var iconWrapperStyle = 'background-color: ' + bgColor + ';';
         var iconWrapper = '<div class=\"block-icon-wrapper\" ' +
                           'style=\"' + iconWrapperStyle + '\">' +
                           styledSvg + '</div>';
@@ -233,7 +273,10 @@ js_blk_selectize_render <- function() {
                      '</div>' + pkgBadge + '</div>' +
                    descHtml + '</div>' + '</div>';
       }
-    }"
+    };
+  })()",
+      icon_style
+    )
   )
 }
 
@@ -368,6 +411,9 @@ block_registry_selectize <- function(id, blocks = list_blocks()) {
     }
   )
 
+  # Get icon style setting
+  icon_style <- blockr_option("icon_style", "light")
+
   tagList(
     css_block_selectize(),
     selectizeInput(
@@ -381,7 +427,7 @@ block_registry_selectize <- function(id, blocks = list_blocks()) {
         searchField = c("label", "description", "searchtext"),
         placeholder = "Type to search",
         openOnFocus = FALSE,
-        render = js_blk_selectize_render()
+        render = js_blk_selectize_render(icon_style)
       )
     )
   )
@@ -588,6 +634,9 @@ board_select <- function(
     }
   )
 
+  # Get icon style setting
+  icon_style <- blockr_option("icon_style", "light")
+
   tagList(
     css_block_selectize(),
     tags$style(HTML(
@@ -624,7 +673,7 @@ board_select <- function(
           placeholder = "Type to search blocks...",
           openOnFocus = FALSE,
           plugins = list("remove_button", "drag_drop"),
-          render = js_blk_selectize_render()
+          render = js_blk_selectize_render(icon_style)
         )
         if (!is.null(selected) && length(selected) > 0) {
           # Preselect items - items should be an array of values

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,24 +136,38 @@ blk_icon_data_uri <- function(icon_svg, color, size = 48) {
   icon_content <- sub("^<svg[^>]*>", "", icon_svg)
   icon_content <- sub("</svg>$", "", icon_content)
 
-  # Create outer SVG with colored rounded rectangle and white icon
+  # Create outer SVG with colored rounded rectangle and icon
   icon_size <- size * 0.6  # Icon takes 60% of total size
   icon_offset <- size * 0.2  # Center the icon
   corner_radius <- size * 0.15  # 15% corner radius
+
+  # Get icon style setting: "light" or "solid"
+  style <- blockr_option("icon_style", "light")
+
+  # Configure based on style
+  if (style == "light") {
+    # Light: translucent background, solid colored icon
+    bg_opacity <- "0.3"
+    icon_fill <- color
+  } else {
+    # Solid: solid background, white icon
+    bg_opacity <- "1"
+    icon_fill <- "white"
+  }
 
   svg <- sprintf(
     "
 <svg xmlns=\"http://www.w3.org/2000/svg\"
      width=\"%d\" height=\"%d\" viewBox=\"0 0 %d %d\">
-  <rect width=\"%d\" height=\"%d\" rx=\"%g\" ry=\"%g\" fill=\"%s\"/>
-  <g transform=\"translate(%g, %g)\" fill=\"white\">
+  <rect width=\"%d\" height=\"%d\" rx=\"%g\" ry=\"%g\" fill=\"%s\" fill-opacity=\"%s\"/>
+  <g transform=\"translate(%g, %g)\" fill=\"%s\">
     <svg width=\"%g\" height=\"%g\" viewBox=\"0 0 16 16\">%s</svg>
   </g>
 </svg>
     ",
     size, size, size, size,
-    size, size, corner_radius, corner_radius, color,
-    icon_offset, icon_offset,
+    size, size, corner_radius, corner_radius, color, bg_opacity,
+    icon_offset, icon_offset, icon_fill,
     icon_size, icon_size, icon_content
   )
 


### PR DESCRIPTION
Not sure how important this is, but it may be that lighter icons look more professional. This let's you set it by options:

```
options(blockr.icon_style = "solid")
options(blockr.icon_style = "light")    # default
```

So you can choose between:

<img width="500" height="530" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/805efd93-6c6b-4c52-a255-1f8ad289e25e" />

<img width="500" height="501" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/707a24bc-79b4-46dd-91ea-22ba7153fa53" />

It also affect the modals.