### PR TITLE
avoid sending empty messages to JS

### DIFF
--- a/R/g6r.R
+++ b/R/g6r.R
@@ -477,8 +477,13 @@ update_combos <- function(stacks, board, proxy = blockr_g6_proxy()) {
     to_add <- setdiff(new_stack_blocks, cur_stack_blocks)
     to_remove <- setdiff(cur_stack_blocks, new_stack_blocks)
 
-    remove_nodes_from_combo(to_remove, proxy)
-    add_nodes_to_combo(to_add, id, proxy)
+    # Prevent no-oops from flooding the JS handlers
+    if (length(to_remove)) {
+      remove_nodes_from_combo(to_remove, proxy)
+    }
+    if (length(to_add)) {
+      add_nodes_to_combo(to_add, id, proxy)
+    }
   }
 
   invisible()


### PR DESCRIPTION
@nbenn 

This can fix empty messages seen in #51. Alternative, is g6R does something like:

```r
g6_data_proxy <- function(graph, el, action, type) {
 if (length(el) == 0) return(graph)
}
```

I'd prefer 2.