### PR TITLE
Add tooltips to toolbar

### DIFF
--- a/R/ext.R
+++ b/R/ext.R
@@ -160,7 +160,8 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.zoomTo(graph.getZoom() + 0.1);
-      }"
+      }",
+      tooltip = "Zoom in"
     ),
     new_toolbar_item(
       id = "zoom_out",
@@ -170,7 +171,8 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.zoomTo (graph.getZoom() - 0.1);
-      }"
+      }",
+      tooltip = "Zoom out"
     ),
     new_toolbar_item(
       id = "auto_fit",
@@ -180,7 +182,8 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.fitView();
-      }"
+      }",
+      tooltip = "Auto fit"
     ),
     new_toolbar_item(
       id = "layout",
@@ -190,7 +193,8 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.layout();
-      }"
+      }",
+      tooltip = "Update layout"
     ),
     new_toolbar_item(
       id = "add_block",
@@ -203,7 +207,8 @@ toolbar_items.dag_extension <- function(x) {
           ns("add_block")
         )
       },
-      action = add_block_action("add_block")
+      action = add_block_action("add_block"),
+      tooltip = "Add block"
     ),
     new_toolbar_item(
       id = "add_stack",
@@ -216,7 +221,8 @@ toolbar_items.dag_extension <- function(x) {
           ns("add_stack")
         )
       },
-      action = add_stack_action("add_stack")
+      action = add_stack_action("add_stack"),
+      tooltip = "Add stack"
     ),
     new_toolbar_item(
       id = "remove_selected",
@@ -229,7 +235,8 @@ toolbar_items.dag_extension <- function(x) {
           ns("rm_selected")
         )
       },
-      action = remove_selected_action("rm_selected")
+      action = remove_selected_action("rm_selected"),
+      tooltip = "Remove selected"
     )
   )
 }

--- a/R/ext.R
+++ b/R/ext.R
@@ -160,8 +160,7 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.zoomTo(graph.getZoom() + 0.1);
-      }",
-      tooltip = "Zoom in"
+      }"
     ),
     new_toolbar_item(
       id = "zoom_out",
@@ -171,8 +170,7 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.zoomTo (graph.getZoom() - 0.1);
-      }",
-      tooltip = "Zoom out"
+      }"
     ),
     new_toolbar_item(
       id = "auto_fit",
@@ -182,8 +180,7 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.fitView();
-      }",
-      tooltip = "Auto fit"
+      }"
     ),
     new_toolbar_item(
       id = "layout",
@@ -193,8 +190,7 @@ toolbar_items.dag_extension <- function(x) {
           `#${target.closest('.g6').id}`
         ).getWidget();
         graph.layout();
-      }",
-      tooltip = "Update layout"
+      }"
     ),
     new_toolbar_item(
       id = "add_block",
@@ -207,8 +203,7 @@ toolbar_items.dag_extension <- function(x) {
           ns("add_block")
         )
       },
-      action = add_block_action("add_block"),
-      tooltip = "Add block"
+      action = add_block_action("add_block")
     ),
     new_toolbar_item(
       id = "add_stack",
@@ -221,8 +216,7 @@ toolbar_items.dag_extension <- function(x) {
           ns("add_stack")
         )
       },
-      action = add_stack_action("add_stack"),
-      tooltip = "Add stack"
+      action = add_stack_action("add_stack")
     ),
     new_toolbar_item(
       id = "remove_selected",
@@ -235,8 +229,7 @@ toolbar_items.dag_extension <- function(x) {
           ns("rm_selected")
         )
       },
-      action = remove_selected_action("rm_selected"),
-      tooltip = "Remove selected"
+      action = remove_selected_action("rm_selected")
     )
   )
 }

--- a/R/tool.R
+++ b/R/tool.R
@@ -22,8 +22,12 @@ new_toolbar_item <- function(id, icon, js, action = NULL, tooltip = NULL) {
     is_string(icon),
     is.null(action) || is.function(action),
     is.function(js),
-    (!is.null(tooltip) && is_string(tooltip))
+    is.null(tooltip) || is_string(tooltip)
   )
+
+  if (is.null(tooltip)) {
+    tooltip <- blockr.core::id_to_sentence_case(id)
+  }
 
   structure(
     list(action = action, js = js),

--- a/R/tool.R
+++ b/R/tool.R
@@ -5,11 +5,12 @@
 #' @param id Unique identifier for the toolbar item
 #' @param icon Name of an icon to show in the toolbar
 #' @param js JavaScript code to execute when the entry is selected
+#' @param tooltip Optional tooltip text for the entry.
 #' @param action Action to perform when the entry is selected
 #'
 #' @rdname tool
 #' @export
-new_toolbar_item <- function(id, icon, js, action = NULL) {
+new_toolbar_item <- function(id, icon, js, action = NULL, tooltip = NULL) {
 
   if (is_string(js)) {
     js_string <- js
@@ -20,13 +21,15 @@ new_toolbar_item <- function(id, icon, js, action = NULL) {
     is_string(id),
     is_string(icon),
     is.null(action) || is.function(action),
-    is.function(js)
+    is.function(js),
+    (!is.null(tooltip) && is_string(tooltip))
   )
 
   structure(
     list(action = action, js = js),
     id = id,
     icon = icon,
+    tooltip = tooltip,
     class = "toolbar_item"
   )
 }
@@ -52,6 +55,8 @@ validate_toolbar_items <- function(x) {
 toolbar_item_id <- function(x) attr(x, "id")
 
 toolbar_item_icon <- function(x) attr(x, "icon")
+
+toolbar_item_tooltip <- function(x) attr(x, "tooltip")
 
 toolbar_item_action <- function(x, board, update, proxy) {
 
@@ -138,9 +143,10 @@ build_toolbar <- function(x, ...) {
   }
 
   sprintf(
-    "{ id : '%s' , value : '%s' }",
+    "{ id : '%s' , value : '%s', title: '%s' }",
     toolbar_item_icon(x),
-    toolbar_item_id(x)
+    toolbar_item_id(x),
+    toolbar_item_tooltip(x)
   )
 }
 

--- a/man/tool.Rd
+++ b/man/tool.Rd
@@ -6,7 +6,7 @@
 \alias{toolbar_items}
 \title{Create a toolbar item}
 \usage{
-new_toolbar_item(id, icon, js, action = NULL)
+new_toolbar_item(id, icon, js, action = NULL, tooltip = NULL)
 
 is_toolbar_item(x)
 
@@ -20,6 +20,8 @@ toolbar_items(x)
 \item{js}{JavaScript code to execute when the entry is selected}
 
 \item{action}{Action to perform when the entry is selected}
+
+\item{tooltip}{Optional tooltip text for the entry.}
 
 \item{x}{Object}
 }


### PR DESCRIPTION
@nbenn 

Looking at the DOM elements, turns out that tooltips are an undocumented feature of g6 🫤
We only have to fill in the title attribute in the configuration.

This is of course not the best looking tooltips ever but they work.

<img width="482" height="105" alt="Screenshot 2025-11-26 at 11 11 27" src="https://github.com/user-attachments/assets/3317fc5e-ac52-463a-bd0a-6f9b19457c4c" />
<img width="159" height="229" alt="Screenshot 2025-11-26 at 11 07 54" src="https://github.com/user-attachments/assets/563fbea3-6115-44fb-8617-b1a276921251" />
