### PR TITLE
Badge tweaks

### DIFF
--- a/R/ext.R
+++ b/R/ext.R
@@ -253,9 +253,12 @@ extension_block_callback.dag_extension <- function(x, ...) {
         n <- n_cnd()
 
         badge <- list(
-          text = format(n),
+          text = "",
           placement = "right-top",
-          backgroundFill = "#000"
+          backgroundFill = "#dc2626",
+          stroke = "#fff",
+          lineWidth = 2,
+          padding = c(5, 5)
         )
 
         node_config <- list(

--- a/R/ext.R
+++ b/R/ext.R
@@ -242,7 +242,7 @@ extension_block_callback.dag_extension <- function(x, ...) {
            session = get_session()) {
 
     n_cnd <- reactive(
-      sum(lengths(conditions()))
+      sum(lengths(conditions()$error))
     )
 
     badge_count <- reactiveVal(0L)


### PR DESCRIPTION
<img width="348" height="483" alt="image" src="https://github.com/user-attachments/assets/05eaa487-4aeb-4937-a124-beec3c2c3643" />

fixes #77 

- red dot, without number, since the number is quite meaningless
- don't show warnings (ggplot 2 above showed a badge before)