### PR TITLE
try catch: When restoring the dag, to avoid a crash

### DIFF
--- a/R/g6r.R
+++ b/R/g6r.R
@@ -332,7 +332,20 @@ init_g6 <- function(board, graph = NULL, ..., session = get_session()) {
   if (is.null(graph)) {
     res <- g6_from_board(board)
   } else {
-    res <- g6_from_graph(as_graph(graph))
+    res <- tryCatch(
+      g6_from_graph(as_graph(graph)),
+      error = function(e) {
+        notify(
+          paste(
+            "DAG could not be restored from saved state, rebuilding from",
+            "board. Details:", conditionMessage(e)
+          ),
+          type = "warning",
+          session = session
+        )
+        g6_from_board(board)
+      }
+    )
   }
 
   res <- set_g6_options(res)


### PR DESCRIPTION
Not having this caused a few crashes when restoring workflows.

The underlying problem may well be with the blocks, but having a warning and a fallback makes debugging and UX much easier.

