### PR TITLE
Update test-ext.R mod payload to blockr.core's delta shape

### DIFF
--- a/tests/testthat/test-ext.R
+++ b/tests/testthat/test-ext.R
@@ -153,20 +153,19 @@ testServer(
       "graph-batch_delete" = TRUE
     )
 
-    # Remove node from combo
-    stacks <- board_stacks(board$board)
-    tmp_stack_1 <- stacks[[1]]
-    stack_blocks(tmp_stack_1) <- stack_blocks(tmp_stack_1)[1]
-    # Add node to combo
-    tmp_stack_2 <- stacks[[2]]
-    stack_blocks(tmp_stack_2) <- "d"
-    mod_stacks <- as_stacks(set_names(
-      list(tmp_stack_1, tmp_stack_2),
-      board_stack_ids(board$board)
-    ))
+    # blockr.core's mod slot now expects partial-args deltas keyed by
+    # entry ID rather than full block / stack objects. stack_1 is being
+    # removed in the same update so it cannot also appear in mod.
 
-    # Update block title
-    mod_blocks <- set_names(board_blocks(board$board)[c("a", "b")], c("a_new", "b_new"))
+    mod_stacks <- list(
+      stack_2 = list(blocks = "d")
+    )
+
+    # Block names: rename blocks a and b via the block_name delta key.
+    mod_blocks <- list(
+      a = list(block_name = "a_new"),
+      b = list(block_name = "b_new")
+    )
 
     update(
       list(


### PR DESCRIPTION
## Summary

- blockr.core's PR https://github.com/BristolMyersSquibb/blockr.core/pull/176 changes `blocks$mod`, `links$mod`, and `stacks$mod` to require **partial-args deltas** (`list(<id> = list(<arg> = <val>, ...))`) rather than full block / stack / link objects. The validator now rejects the old shape with `board_update_*_mod_entry_invalid`.
- This repo's `tests/testthat/test-ext.R` constructs a mod payload (lines 156-175) using the old shape. The mock `update` reactiveVal in that test is never picked up by a real board observer, so validation never fires — which is why revdep CI never caught this. Even under the previous semantics the payload was wrong:
  - `mod_blocks <- set_names(board_blocks(...)[c("a","b")], c("a_new","b_new"))` re-keyed a blocks object (block IDs are immutable; this would have left dangling references to `a` and `b` in links/stacks).
  - `mod_stacks` modified `stack_1` while the same update also `rm`'d it.
- This PR ports the payload to the new delta shape:
  - `mod_blocks = list(a = list(block_name = "a_new"), b = list(block_name = "b_new"))` — what the "Update block title" comment actually intended.
  - `mod_stacks = list(stack_2 = list(blocks = "d"))` — `stack_1` removed from `mod` since it's also in `rm`.

Production code in `R/` only uses `add` / `rm`, never `mod`, so nothing else needs updating.