### PR TITLE
Switch CI to PR-gate pipeline (blockr.ci@17-pr-gates)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,13 @@
 on:
-  push:
-    branches: main
   pull_request:
+    branches: main
   merge_group:
 
 name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@17-pr-gates
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
-    permissions:
-      contents: write

--- a/.github/workflows/deps-rerun.yaml
+++ b/.github/workflows/deps-rerun.yaml
@@ -7,6 +7,6 @@ name: deps-rerun
 
 jobs:
   rerun:
-    uses: cynkra/blockr.ci/.github/workflows/deps-rerun.yaml@main
+    uses: cynkra/blockr.ci/.github/workflows/deps-rerun.yaml@17-pr-gates
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches: main
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@17-pr-gates
+    secrets:
+      BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

Switch blockr.dag onto the new blockr.ci PR-gate pipeline, mirroring the migration already merged into blockr.dock, blockr.core and blockr.assistant. The three reusable workflows now pin `cynkra/blockr.ci@17-pr-gates` (the in-flight CI restructure, blockr.ci#19); when that branch merges, all repos flip `@17-pr-gates → @main` together.

- `ci.yaml` — drop the `push: main` trigger and the job-level `contents: write` permission (site deploys move to `pkgdown.yaml`); the job now runs only on PRs to `main` and on the merge queue.
- `pkgdown.yaml` — new; deploys the pkgdown site on push to `main`.
- `deps-rerun.yaml` — re-pin to `@17-pr-gates`.

This is the **cutover** PR: it renames the reported check contexts from the old unified `ci` job to the aggregated `ci / lint`, `ci / smoke`, `ci / pkgdown-dev`, `ci / coverage`, `ci / check-all`. Its own run reports under the new names, so it can satisfy the merge-queue required-checks list directly once the ruleset below is in place — no rebase dance needed for this PR.

**No `revdep` job** (unlike dock/core, like blockr.md/blockr.assistant): nothing in the building-block stack depends on blockr.dag — only the `blockr` umbrella imports it and `blockr.dm` suggests it, and no sibling gates those as revdeps. So dag's queue requires the five `ci/*` checks only, with no `revdep / revdep-all`.

## Branch protection to mirror (repo settings — not in this PR)

dock/core/assistant each carry two **repository rulesets** on the default branch, both with enforcement **Active**. The workflow files in this PR are the code change; the rulesets live in repo settings and have to be applied there. Replicate them on blockr.dag as below — values are copied from blockr.dock, adjusted for dag's missing revdep job.

### `main queue` — routes every merge through the queue

| Setting | Value |
| --- | --- |
| Target | Default branch (`main`) |
| Restrict deletions | on |
| Block force pushes (non-fast-forward) | on |
| Require merge queue | on — merge method **Merge commit**, grouping **ALLGREEN**, build max 5, merge 1–5 per batch, 5-min minimum wait, 60-min check timeout |
| Require status checks to pass | `ci / lint`, `ci / smoke`, `ci / pkgdown-dev`, `ci / coverage`, `ci / check-all` — "require branches up to date" **off** |
| Bypass list | **empty** — nobody skips the queue or the required checks, admins included |

dock and core additionally require `revdep / revdep-all` in this list; dag omits it because it has no revdep job.

### `main review` — one approval, admins exempt from review

| Setting | Value |
| --- | --- |
| Target | Default branch (`main`) |
| Require a pull request before merging | on — **1** approving review; dismiss-stale-approvals, require-code-owner-review, require-last-push-approval and require-conversation-resolution all **off** |
| Allowed merge methods | merge, squash, rebase (the queue forces a merge commit regardless) |
| Bypass list | **Repository admin** role, mode **exempt** — admins may merge without an approving review but still pass the queue + checks |

The split is deliberate: the review ruleset lets admins skip *review*, while the queue ruleset has an empty bypass list so everyone — admins included — still goes through the merge queue and the required checks. The queue's `merge_method: MERGE` is what governs the actual merge, so merges land as regular merge commits per the repo convention.

Importable JSON (GitHub → Settings → Rules → Rulesets → New ruleset → Import a ruleset):

<details>
<summary><code>main queue</code> ruleset JSON</summary>

```json
{
  "name": "main queue",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
  },
  "rules": [
    { "type": "deletion" },
    { "type": "non_fast_forward" },
    {
      "type": "merge_queue",
      "parameters": {
        "merge_method": "MERGE",
        "max_entries_to_build": 5,
        "min_entries_to_merge": 1,
        "max_entries_to_merge": 5,
        "min_entries_to_merge_wait_minutes": 5,
        "grouping_strategy": "ALLGREEN",
        "check_response_timeout_minutes": 60
      }
    },
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "do_not_enforce_on_create": false,
        "required_status_checks": [
          { "context": "ci / lint" },
          { "context": "ci / smoke" },
          { "context": "ci / pkgdown-dev" },
          { "context": "ci / coverage" },
          { "context": "ci / check-all" }
        ]
      }
    }
  ],
  "bypass_actors": []
}
```
</details>

<details>
<summary><code>main review</code> ruleset JSON</summary>

```json
{
  "name": "main review",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
  },
  "rules": [
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 1,
        "dismiss_stale_reviews_on_push": false,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": false,
        "required_reviewers": [],
        "allowed_merge_methods": ["merge", "squash", "rebase"]
      }
    }
  ],
  "bypass_actors": [
    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "exempt" }
  ]
}
```
</details>
