### PR TITLE
Relabel DAG node on block rename

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Added support for node ports from g6R.
 - Fix [#86](https://github.com/BristolMyersSquibb/blockr.dag/issues/86).
 - Fix [#110](https://github.com/BristolMyersSquibb/blockr.dag/issues/110): copy/cut keyboard shortcuts no longer hijack plain text selections (column names, error messages, etc.).
+- Fix [#123](https://github.com/BristolMyersSquibb/blockr.dag/issues/123): renaming a block now relabels its DAG node instead of erroring. `update_observer()` handed blockr.core's partial-argument `blocks$mod` delta straight to `update_nodes()` (which needs full `block` objects); it now updates the node label directly from the delta.
 
 # blockr.dag 0.1.0
 

--- a/R/g6r.R
+++ b/R/g6r.R
@@ -695,9 +695,18 @@ add_nodes <- function(blocks, board, proxy = blockr_g6_proxy()) {
   invisible()
 }
 
-update_nodes <- function(blocks, board, proxy = blockr_g6_proxy()) {
-  nodes <- g6_nodes_from_blocks(blocks, board_stacks(board))
-  g6_update_nodes(proxy, nodes)
+relabel_nodes <- function(mods, proxy = blockr_g6_proxy()) {
+
+  # A `blocks$mod` delta only ever carries `block_name`, so a rename is
+  # just a label change; g6 merges the partial style, keeping the icon.
+  g6_update_nodes(
+    proxy,
+    map(
+      list,
+      id = to_g6_node_id(names(mods)),
+      style = map(list, labelText = chr_xtr(mods, "block_name"))
+    )
+  )
 
   invisible()
 }

--- a/R/srv.R
+++ b/R/srv.R
@@ -95,7 +95,7 @@ update_observer <- function(update, board, proxy) {
       }
 
       if (length(upd$blocks$mod)) {
-        update_nodes(upd$blocks$mod, board$board, proxy)
+        relabel_nodes(upd$blocks$mod, proxy)
       }
 
       if (length(upd$links$add)) {

--- a/tests/testthat/test-ext.R
+++ b/tests/testthat/test-ext.R
@@ -187,6 +187,44 @@ testServer(
   }
 )
 
+test_that("a block-name mod delta relabels the node", {
+  captured <- NULL
+  local_mocked_bindings(
+    g6_update_nodes = function(proxy, nodes) {
+      captured <<- nodes
+      invisible()
+    }
+  )
+
+  rename_board <- blockr.dock::new_dock_board(
+    blocks = c(a = new_dataset_block("iris"))
+  )
+
+  testServer(
+    function(id, board, update) {
+      moduleServer(
+        id,
+        function(input, output, session) {
+          update_observer(update, board, blockr_g6_proxy(session))
+        }
+      )
+    },
+    args = list(
+      board = reactiveValues(board = rename_board),
+      update = reactiveVal(NULL)
+    ),
+    {
+      update(
+        list(blocks = list(mod = list(a = list(block_name = "renamed"))))
+      )
+      session$flushReact()
+
+      expect_identical(captured[[1L]]$id, to_g6_node_id("a"))
+      expect_identical(captured[[1L]]$style$labelText, "renamed")
+    }
+  )
+})
+
 test_that("extension_block_callback works", {
   ext_cb <- extension_block_callback(new_dag_extension())
 


### PR DESCRIPTION
## Summary

- Renaming a block errored the DAG node relabel: `update_observer()`'s `blocks$mod` branch passed blockr.core's partial-argument delta (`list(id = list(block_name = …))`) to `update_nodes()`, which rebuilds full nodes from `block` objects and chokes on the plain list. A `blocks$mod` delta only ever carries `block_name` (block state flows through external control), so the new label is already in hand.
- `relabel_nodes()` updates the node label directly from the delta — no delta resolution, no block rebuild. Safe because g6 merges the partial `style` (dag's own error-badge update relies on the same). `update_nodes()` had no other caller and is dropped.
- Regression test drives a rename through `update_observer` and asserts the relabel; it fails against the unfixed branch.

What #123 frames as a flaky testServer binding error is a conflation. In dock's revdep the result is `[ FAIL 1 | WARN 1 ]`: the FAIL is `test-e2e.R`'s `set_inputs` racing the unbound add-block control ("Unable to find input binding"), and the WARN is this deterministic `test-ext.R:186` defect (`as_blocks.list` via `update_observer`). A testServer has no browser and cannot emit that string. The flaky failure that ejects the build is #122; this PR fixes the warning.

Stacked on #124 (the #122 fix) — retarget to `main` once it lands.

Fixes #123
