### PR TITLE
fix #127: reliably trigger append on edge-drag to canvas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Fix [#86](https://github.com/BristolMyersSquibb/blockr.dag/issues/86).
 - Fix [#110](https://github.com/BristolMyersSquibb/blockr.dag/issues/110): copy/cut keyboard shortcuts no longer hijack plain text selections (column names, error messages, etc.).
 - Fix [#123](https://github.com/BristolMyersSquibb/blockr.dag/issues/123): renaming a block now relabels its DAG node instead of erroring. `update_observer()` handed blockr.core's partial-argument `blocks$mod` delta straight to `update_nodes()` (which needs full `block` objects); it now updates the node label directly from the delta.
+- Fix [#127](https://github.com/BristolMyersSquibb/blockr.dag/issues/127): dragging an edge from a node port onto the canvas only triggered the append/prepend action intermittently ("every second time"). The `added_edge` input was set without `{priority: "event"}`, so a repeat drag with an identical payload was de-duplicated by Shiny and the observer never fired. The canvas-drop handler also silently discarded the gesture via `req(edge$portType)`. Both `added_edge` emits now use event priority, and the handler defaults to append (output port) instead of bailing.
 
 # blockr.dag 0.1.0
 

--- a/R/g6r.R
+++ b/R/g6r.R
@@ -208,7 +208,7 @@ set_g6_behaviors <- function(graph, ..., ns) {
     g6R::create_edge(
       enable = JS(
         "(e) => {
-          return e.targetType === 'node' && e.targetType !== 'combo'
+          return e.targetType === 'node'
         }"
       ),
       onFinish = JS(
@@ -226,7 +226,8 @@ set_g6_behaviors <- function(graph, ..., ns) {
                   targetType: 'canvas',
                   sourcePort: edge.style?.sourcePort,
                   portType: edge.style?.portType
-                }
+                },
+                {priority: 'event'}
               );
               return;
             }
@@ -244,7 +245,8 @@ set_g6_behaviors <- function(graph, ..., ns) {
                   targetType: edge.targetType,
                   sourcePort: edge.style.sourcePort,
                   targetPort: edge.style.targetPort
-                }
+                },
+                {priority: 'event'}
               );
               // We will recreate the edge from the R side with correct ID
               graph.removeEdgeData([edge.id]);
@@ -696,7 +698,6 @@ add_nodes <- function(blocks, board, proxy = blockr_g6_proxy()) {
 }
 
 relabel_nodes <- function(mods, proxy = blockr_g6_proxy()) {
-
   # A `blocks$mod` delta only ever carries `block_name`, so a rename is
   # just a label change; g6 merges the partial style, keeping the icon.
   g6_update_nodes(

--- a/R/srv.R
+++ b/R/srv.R
@@ -194,10 +194,12 @@ actions_observers <- function(actions, proxy) {
     req(input$added_edge$targetType == "canvas"),
     {
       edge <- input$added_edge
-      req(edge$portType)
 
+      # g6 only starts an edge from a grabbed port, so portType is normally
+      # set. Default to append (output port) rather than silently dropping
+      # the gesture if it is ever missing.
       switch(
-        edge$portType,
+        coal(edge$portType, "output"),
         output = actions[["append_block_action"]](edge$source),
         input = actions[["prepend_block_action"]](edge$source)
       )


### PR DESCRIPTION
Closes #127.

## Symptom

Dragging an edge from a node's output port onto empty canvas triggered the append (or prepend) block action only intermittently, classically "every second time" on production.

## Root cause

Two issues in the canvas-drop path:

1. **Shiny input de-duplication.** [R/g6r.R](R/g6r.R) `create_edge` `onFinish` set `Shiny.setInputValue('…-added_edge', {…})` **without** `{priority: "event"}`. Shiny only invalidates an input when its value changes, so a second drag carrying a byte-identical payload (same source, same port) was dropped and the `canvas_drop` observer never re-fired. The alternating success ("every second time") is the de-dup signature.
2. **Silent gate.** [R/srv.R](R/srv.R) `canvas_drop` ran `req(edge$portType)` and silently aborted whenever `portType` was absent.

## Fix

- Add `{priority: "event"}` to **both** `added_edge` emits (canvas-drop and node-to-node branches) so each gesture fires as an event regardless of payload equality.
- Replace `req(edge$portType)` with `switch(coal(edge$portType, "output"), …)` so a drop defaults to append (the output-port case) instead of being silently discarded.

## Scope / not included

This is the reliable-trigger fix (issues #1 and #2 from the investigation). The harder-to-hit-port behaviour and the `drag-element` enable coordination live in g6R and are tracked in [cynkra/g6R#48](https://github.com/cynkra/g6R/issues/48); not addressed here.

## Verification

- `devtools::load_all()` clean; example app (`inst/examples/empty`) starts (`Listening on …`, HTTP 200).
- Manual: drag from an output port to canvas repeatedly; the append sidebar now opens every time, including consecutive drags from the same port.
