### PR TITLE
Simplify drag_element enable; rely on g6R for edge-creation drag pause

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,12 @@ Imports:
     blockr.core (>= 0.1.2.9000),
     blockr.dock (>= 0.1.1),
     shiny,
-    g6R (>= 0.6.0),
+    g6R (>= 0.6.0.9000),
     jsonlite,
     htmltools
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    cynkra/g6R
 Suggests:
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Fix [#86](https://github.com/BristolMyersSquibb/blockr.dag/issues/86).
 - Fix [#110](https://github.com/BristolMyersSquibb/blockr.dag/issues/110): copy/cut keyboard shortcuts no longer hijack plain text selections (column names, error messages, etc.).
 - Fix [#123](https://github.com/BristolMyersSquibb/blockr.dag/issues/123): renaming a block now relabels its DAG node instead of erroring. `update_observer()` handed blockr.core's partial-argument `blocks$mod` delta straight to `update_nodes()` (which needs full `block` objects); it now updates the node label directly from the delta.
+- Dropped the assist-node probe from the `drag_element` `enable` predicate. g6R ([cynkra/g6R#49](https://github.com/cynkra/g6R/pull/49)) now pauses node dragging during port edge-creation and restores the consumer predicate on drop, so the probe was redundant. The predicate is back to just suppressing drag on `shift`/`alt`. Requires `g6R (>= 0.6.0.9000)`.
 
 # blockr.dag 0.1.0
 

--- a/R/g6r.R
+++ b/R/g6r.R
@@ -172,21 +172,14 @@ set_g6_behaviors <- function(graph, ..., ns) {
         }"
       )
     ),
-    # So we can add node to stack from the UI by drag and drop
-    # Disable drag when edge creation from port is active
+    # So we can add node to stack from the UI by drag and drop.
+    # Shift/alt are reserved for canvas pan / brush select. Suppressing
+    # node drag during port edge-creation is handled by g6R's create_edge
+    # (it pauses drag-element on port-grab and restores this predicate on
+    # drop), so no assist-node probe is needed here. Requires g6R with
+    # cynkra/g6R#49.
     drag_element(
-      enable = JS(
-        "(e) => {
-          if (e.shiftKey || e.altKey) return false;
-          // Access graph via HTMLWidgets and check if edge creation is in progress
-          const target = e.nativeEvent?.target;
-          const graph = HTMLWidgets.find(`#${target?.closest?.('.g6')?.id}`)?.getWidget();
-          try {
-            if (graph?.getNodeData?.('g6-create-edge-assist-node-id')) return false;
-          } catch (err) {}
-          return true;
-        }"
-      ),
+      enable = JS("(e) => !e.shiftKey && !e.altKey"),
       # For now, we prevent nodes from being dropped outside combo.
       dropEffect = "move"
     ),


### PR DESCRIPTION
Follow-up to [cynkra/g6R#49](https://github.com/cynkra/g6R/pull/49) (the #3 item from the edge-drag investigation; see also #127 / #130).

## Background

While debugging the intermittent edge-drag-to-canvas append (#127), we found that g6R's `create_edge` did not actually coordinate with `drag-element`: its pause/resume used the array form of `updateBehavior(...)`, a silent no-op in G6 5.0.49. So the only thing suppressing node dragging during a port edge-drag was our own assist-node probe in `drag_element(enable = ...)`.

[cynkra/g6R#49](https://github.com/cynkra/g6R/pull/49) fixes this: `create_edge` now pauses `drag-element`/`drag-element-force` on port-grab (single-key form) and **restores the consumer-supplied `enable` predicate verbatim** on drop, gated to the drag trigger.

## Change

- Drop the assist-node probe from `drag_element(enable = ...)` ([R/g6r.R](R/g6r.R)); it is now redundant. The predicate is back to just suppressing node drag on `shift`/`alt`, which g6R snapshots and restores across edge creation.
- Pin dev g6R via `Remotes: cynkra/g6R` and bump `g6R (>= 0.6.0.9000)`, since the fix is not yet on CRAN. (Same dev-pin pattern already used for `blockr.core`.)

## Verification

g6R 0.6.0.9000 (merged #49) installed locally. Headless chromote against the empty example app:

- No JS console errors; graph initializes.
- `getBehaviors()` shows `drag-element` with a function `enable` and `create-edge` present.
- Pause-on-port-grab / restore-on-drop of the consumer predicate is covered by g6R#49's own chromote test.

## Notes

- Independent of #130 (different regions of `g6r.R`); branched off `main`.
- The "hard to grab the port" root cause is tracked separately in [cynkra/g6R#50](https://github.com/cynkra/g6R/issues/50).
- This cannot go to CRAN until a g6R release carrying #49 is available.
