### PR TITLE
Point CI workflows at BristolMyersSquibb/blockr.ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,7 +6,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/pkgdown.yaml@main
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     jsonlite,
     htmltools
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    nbenn/shinytest2@wait-for-app-serving
 Suggests:
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,13 +27,15 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Imports:
     blockr.core (>= 0.1.2.9000),
-    blockr.dock (>= 0.1.1),
+    blockr.dock (>= 0.1.2),
     shiny,
     g6R (>= 0.6.0),
     jsonlite,
     htmltools
 Remotes:
     BristolMyersSquibb/blockr.core,
+    BristolMyersSquibb/blockr.dock,
+    BristolMyersSquibb/blockr.ui,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     knitr,


### PR DESCRIPTION
## Summary

- Swap the `uses:` owner from `cynkra` to `BristolMyersSquibb` in `.github/workflows/ci.yaml` and `.github/workflows/pkgdown.yaml` (path and `@main` ref unchanged) after blockr.ci's transfer to the BristolMyersSquibb org.
- The `cynkra/blockr.ci` redirect keeps CI working today, but it breaks silently if the `cynkra` name is ever reclaimed; the explicit owner also reads clearer.
- Reusable-workflow and job names are unchanged, so no required-status-check or ruleset updates are needed.

Fixes #132

Fixes #134
