### PR TITLE
Pin shinytest2 to wait-for-app-serving for e2e bind race

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     jsonlite,
     htmltools
 Remotes:
-    BristolMyersSquibb/blockr.core
+    BristolMyersSquibb/blockr.core,
+    nbenn/shinytest2@wait-for-app-serving
 Suggests:
     knitr,
     rmarkdown,


### PR DESCRIPTION
## Summary

- `variadic app works` (test-e2e.R) fails on CI with "Shiny app did not become stable in 15000ms". This is the shiny#4400 bind race, not an app regression: shiny prints "Listening on" before it binds the socket, so on a loaded runner `AppDriver$new()` navigates to the not-yet-bound port, lands on the browser error page, and that recovery races shinytest2's readiness checks. The variadic app itself initializes cleanly (HTTP 200, no errors) against current core/dock/ui.
- Fix: pin `nbenn/shinytest2@wait-for-app-serving`, which polls the port with `pingr` before navigating — no new dependency, and inert once the port is bound. This is the same pin blockr.dock already carries. Temporary, like dock's: revert once rstudio/shinytest2#448 lands upstream.
- The `new_stack` "ctor matched by multiple actual arguments" warning the issue cited was a transient core@main state and no longer reproduces (the full suite runs warning-free against core@main), so no call-site change is needed here.

Stacked on #133. dag's CI can't resolve `cynkra/blockr.ci` after the org move, so a PR based on `main` fails at workflow startup; basing this on `132-blockr-ci-org` lets the merge ref carry that repoint so CI can run. Retarget to `main` once #133 lands — the `Fixes #134` link activates then.

Fixes #134