### PR TITLE
Rework block ports: always visible, fixed radius, label-bottom output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,13 +29,14 @@ Imports:
     blockr.core (>= 0.1.2.9000),
     blockr.dock (>= 0.1.2),
     shiny,
-    g6R (>= 0.6.0),
+    g6R (>= 0.6.0.9000),
     jsonlite,
     htmltools
 Remotes:
     BristolMyersSquibb/blockr.core,
     BristolMyersSquibb/blockr.dock,
     BristolMyersSquibb/blockr.ui,
+    cynkra/g6R,
     nbenn/shinytest2@wait-for-app-serving
 Suggests:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Add support for collapsible nodes and combos, through g6R.
 - Reworked actions. Inherits from `blockr.dock`.
 - Added support for node ports from g6R.
+- Reworked block ports: ports are now always visible (rather than hover-only) with a fixed radius, and the output port uses the `label-bottom` placement. Pairs with g6R's port-grab tolerance so a near-miss on a port still starts an edge. Requires `g6R (>= 0.6.0.9000)`.
 - Fix [#86](https://github.com/BristolMyersSquibb/blockr.dag/issues/86).
 - Fix [#110](https://github.com/BristolMyersSquibb/blockr.dag/issues/110): copy/cut keyboard shortcuts no longer hijack plain text selections (column names, error messages, etc.).
 - Fix [#123](https://github.com/BristolMyersSquibb/blockr.dag/issues/123): renaming a block now relabels its DAG node instead of erroring. `update_observer()` handed blockr.core's partial-argument `blocks$mod` delta straight to `update_nodes()` (which needs full `block` objects); it now updates the node label directly from the delta.

--- a/R/g6r.R
+++ b/R/g6r.R
@@ -453,9 +453,9 @@ create_block_ports <- function(block, id) {
       key = sprintf("%s-in", id),
       label = "in",
       arity = Inf,
-      visibility = "hover",
       placement = "top",
-      fill = fill_col
+      fill = fill_col,
+      r = 3
     ))
   } else if (length(inputs) == 1 && arity == 1) {
     # Mono input
@@ -463,9 +463,9 @@ create_block_ports <- function(block, id) {
       key = sprintf("%s-%s", id, inputs[1]),
       label = inputs[1],
       arity = 1,
-      visibility = "hover",
       placement = "top",
-      fill = fill_col
+      fill = fill_col,
+      r = 3
     ))
   } else if (length(inputs) > 1) {
     # Multi input
@@ -480,9 +480,9 @@ create_block_ports <- function(block, id) {
         key = sprintf("%s-%s", id, inputs[i]),
         label = inputs[i],
         arity = 1,
-        visibility = "hover",
         placement = c(xs[i], 0),
-        fill = fill_col
+        fill = fill_col,
+        r = 3
       )
     })
   }
@@ -495,9 +495,9 @@ create_block_ports <- function(block, id) {
       key = out_id,
       label = NULL,
       arity = Inf,
-      visibility = "hover",
-      placement = "bottom",
-      fill = fill_col
+      placement = "label-bottom",
+      fill = fill_col,
+      r = 3
     ))
   )
   do.call(g6_ports, ports)
@@ -696,7 +696,6 @@ add_nodes <- function(blocks, board, proxy = blockr_g6_proxy()) {
 }
 
 relabel_nodes <- function(mods, proxy = blockr_g6_proxy()) {
-
   # A `blocks$mod` delta only ever carries `block_name`, so a rename is
   # just a label change; g6 merges the partial style, keeping the icon.
   g6_update_nodes(


### PR DESCRIPTION
Reworks how block ports render on the DAG, paired with g6R's new port-grab tolerance ([cynkra/g6R#54](https://github.com/cynkra/g6R/pull/54)).

## Changes (`create_block_ports`, [R/g6r.R](R/g6r.R))

- **Always visible:** drop `visibility = "hover"` on input and output ports, so ports show without hovering.
- **Fixed radius:** add `r = 3` to every port, giving the grab tolerance a defined target size.
- **Output placement:** output port moves from `"bottom"` to `"label-bottom"` (a placement introduced in g6R#54 that sits below the node label).

These are the consuming side of g6R#54: with always-visible, sized ports, g6R's `findNearestPort` snapping lets a near-miss on a port still start an edge instead of dragging the node (addresses the "hard to grab the port" complaint, g6R#50).

## Dependency

`label-bottom` and the grab tolerance live in g6R#54, which is not yet on CRAN, so this pins `cynkra/g6R` via `Remotes` and bumps the floor to `g6R (>= 0.6.0.9000)`. g6R#54 must merge to g6R `main` before CI here goes green / before a CRAN release.

## Verification

g6R#54 installed (clean ~1.75 MB bundle, no `parsedStyle.fill` crash). Served a board with a dataset + subset block over chromote:

- No JS console errors; graph initializes with 2 nodes + 1 edge.
- Data block output port reports `placement: "label-bottom"`, `r: 3`, `visibility: "visible"`.

## Notes

- Independent of #130 (event-priority append) and #131 (drag-element enable simplification); all three touch `g6r.R` in different regions.
- The browser-zoom drop-cancel (g6R#52) is a separate issue, not addressed here.
