### PR TITLE
fix(dag): don't crash on non-rename block mods

### DIFF
--- a/R/g6r.R
+++ b/R/g6r.R
@@ -696,8 +696,19 @@ add_nodes <- function(blocks, board, proxy = blockr_g6_proxy()) {
 }
 
 relabel_nodes <- function(mods, proxy = blockr_g6_proxy()) {
-  # A `blocks$mod` delta only ever carries `block_name`, so a rename is
-  # just a label change; g6 merges the partial style, keeping the icon.
+  # A `blocks$mod` delta can carry any externally controllable argument
+  # (e.g. the assistant configuring a chart with `chart_type`/`group`/...),
+  # not just a rename. Only deltas that actually change `block_name` are
+  # label changes the DAG needs to reflect; ignore the rest. Extracting
+  # `block_name` from a config-only delta would yield a zero-length value
+  # and crash the surrounding observer.
+  mods <- Filter(function(m) !is.null(m[["block_name"]]), mods)
+
+  if (!length(mods)) {
+    return(invisible())
+  }
+
+  # g6 merges the partial style, keeping the icon.
   g6_update_nodes(
     proxy,
     map(


### PR DESCRIPTION
relabel_nodes() assumed every blocks$mod delta is a rename carrying block_name and ran chr_xtr(mods, "block_name"). A config-only modify (e.g. the assistant/ai_ctrl configuring a chart with chart_type/group/ metric/agg_fn) carries no block_name, so the extraction yields a zero-length value and vapply() aborts. Because this runs in the DAG update observer -- outside the assistant flush tryCatch -- it kills the whole Shiny session.

Filter the mod deltas to those that actually change block_name before relabelling, and early-return when none do.