### PR TITLE
Default to canvas renderer; opt into SVG for e2e tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     blockr.core (>= 0.1.2.9000),
     blockr.dock (>= 0.1.2),
     shiny,
-    g6R (>= 0.6.0.9000),
+    g6R (>= 0.6.0.9001),
     jsonlite,
     htmltools
 Remotes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Internal changes
 
+- The DAG now renders with G6's default canvas renderer instead of the SVG renderer. The SVG element reports `offsetWidth == 0`, which broke `g-lite`'s client/canvas coordinate scaling under browser zoom other than 100% (drops and port grabs silently failed below 100%). The SVG renderer is still used for `shinytest2` end-to-end tests via the new `blockr.dag.svg_renderer` option (see `?new_dag_extension`).
 - Label observers for OTEL support.
 - Add support for collapsible nodes and combos, through g6R.
 - Reworked actions. Inherits from `blockr.dock`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Internal changes
 
-- The DAG now renders with G6's default canvas renderer instead of the SVG renderer. The SVG element reports `offsetWidth == 0`, which broke `g-lite`'s client/canvas coordinate scaling under browser zoom other than 100% (drops and port grabs silently failed below 100%). The SVG renderer is still used for `shinytest2` end-to-end tests via the new `blockr.dag.svg_renderer` option (see `?new_dag_extension`).
+- The DAG now renders with G6's default canvas renderer instead of the SVG renderer. The SVG element reports `offsetWidth == 0`, which broke `g-lite`'s client/canvas coordinate scaling under browser zoom other than 100% (drops and port grabs silently failed below 100%). The SVG renderer is still used for `shinytest2` end-to-end tests via the new `blockr.dag.svg_renderer` option (see `?new_dag_extension`). Requires `g6R (>= 0.6.0.9001)`, which keeps the create-edge assist node from crashing the canvas renderer.
 - Label observers for OTEL support.
 - Add support for collapsible nodes and combos, through g6R.
 - Reworked actions. Inherits from `blockr.dock`.

--- a/R/ext.R
+++ b/R/ext.R
@@ -3,6 +3,16 @@
 #' Visualizes the DAG (directed acyclic graph) underlying a board and provides
 #' UI elements to manipulate the board.
 #'
+#' @section Options:
+#' `blockr.dag.svg_renderer`: when `TRUE`, the DAG is rendered with the SVG
+#' renderer instead of the default canvas renderer. Canvas is the default
+#' because the SVG element reports `offsetWidth == 0`, which makes the
+#' underlying `g-lite` client/canvas coordinate scaling ignore the page zoom
+#' factor and desyncs hit-testing below 100% browser zoom. The SVG renderer
+#' keeps every element in the DOM, which the `shinytest2` end-to-end tests need
+#' to query and screenshot, so they opt in via
+#' `AppDriver$new(options = list(blockr.dag.svg_renderer = TRUE))`.
+#'
 #' @param graph A `graph` object (or `NULL`).
 #' @param ... Forwarded to [blockr.dock::new_dock_extension()].
 #'

--- a/R/g6r.R
+++ b/R/g6r.R
@@ -67,13 +67,22 @@ g6_from_graph <- function(graph) {
   )
 }
 
+# Renderer selection. Production uses G6's default canvas renderer: the SVG
+# element reports `offsetWidth == 0`, which makes g-lite's client<->canvas scale
+# ignore the page zoom factor and desyncs hit-testing below 100% browser zoom.
+# The SVG renderer keeps every element in the DOM, which the shinytest2 e2e
+# tests query and screenshot, so those opt in via
+# `options(blockr.dag.svg_renderer = TRUE)` (passed to `AppDriver$new()`).
+use_svg_renderer <- function() {
+  isTRUE(getOption("blockr.dag.svg_renderer", FALSE))
+}
+
 set_g6_options <- function(graph, ...) {
+  renderer <- if (use_svg_renderer()) JS("() => new SVGRenderer()")
   g6_options(
     graph,
     ...,
-    # Required so that elements are in the DOM
-    # for shinytest2 e2e
-    renderer = JS("() => new SVGRenderer()"),
+    renderer = renderer,
     animation = FALSE,
     node = list(
       type = "custom-image-node",

--- a/man/dag.Rd
+++ b/man/dag.Rd
@@ -19,3 +19,15 @@ for visualizing and manipulating DAG workflows.
 Visualizes the DAG (directed acyclic graph) underlying a board and provides
 UI elements to manipulate the board.
 }
+\section{Options}{
+
+\code{blockr.dag.svg_renderer}: when \code{TRUE}, the DAG is rendered with the SVG
+renderer instead of the default canvas renderer. Canvas is the default
+because the SVG element reports \code{offsetWidth == 0}, which makes the
+underlying \code{g-lite} client/canvas coordinate scaling ignore the page zoom
+factor and desyncs hit-testing below 100\% browser zoom. The SVG renderer
+keeps every element in the DOM, which the \code{shinytest2} end-to-end tests need
+to query and screenshot, so they opt in via
+\code{AppDriver$new(options = list(blockr.dag.svg_renderer = TRUE))}.
+}
+

--- a/tests/testthat/test-e2e.R
+++ b/tests/testthat/test-e2e.R
@@ -26,7 +26,9 @@ test_that("variadic app works", {
   app <- AppDriver$new(
     appdir,
     name = "variadic-app",
-    seed = 4323
+    seed = 4323,
+    # e2e assertions need every element in the DOM, so render with SVG.
+    options = list(blockr.dag.svg_renderer = TRUE)
   )
 
   expect_values(app)

--- a/vignettes/blockr.dag.qmd
+++ b/vignettes/blockr.dag.qmd
@@ -58,6 +58,37 @@ serve(
 )
 ```
 
+## Options
+
+blockr.dag's behaviour is tuned through a handful of R `options()`, set before `serve()`. They split into options owned by blockr.dag and options it inherits from [g6R](https://cynkra.github.io/g6R/), the engine that renders and drives the DAG.
+
+### blockr.dag options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `blockr.dag.svg_renderer` | `FALSE` | Render the DAG with g6R's SVG renderer instead of the default canvas renderer. Canvas is the default because the SVG element reports `offsetWidth == 0`, which makes the underlying `g-lite` client/canvas coordinate scaling ignore the page zoom factor and desyncs hit-testing below 100% browser zoom (drops and port grabs silently fail). The SVG renderer keeps every element in the DOM, so it is mainly useful for `shinytest2` end-to-end tests, which opt in via `AppDriver$new(options = list(blockr.dag.svg_renderer = TRUE))`. |
+
+### g6R options
+
+Because blockr.dag renders through g6R, several g6R options shape DAG behaviour. Set them alongside the board:
+
+```{r}
+options(
+  g6R.mode = "dev",
+  g6R.directed_graph = TRUE,
+  g6R.layout_on_data_change = TRUE
+)
+
+serve(new_dock_board(extensions = new_dag_extension()))
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `g6R.mode` | `"prod"` | `"dev"` surfaces in-app notifications (e.g. why an edge drop was rejected); `"prod"` keeps them silent. Use `"dev"` while building. |
+| `g6R.directed_graph` | `FALSE` | Maintain parent/child (tree) relationships as edges and nodes are added or removed through the g6R proxy. A DAG is directed, so this is typically `TRUE`; g6R also auto-enables it when nodes declare `children`. The tree bookkeeping is only kept in sync when you mutate the graph through the proxy functions, not the raw G6 JS API. |
+| `g6R.layout_on_data_change` | `FALSE` | Re-run the layout whenever the graph data changes (a block or edge is added/removed), so the DAG re-arranges itself. With `FALSE`, existing nodes keep their position and only new elements are placed. |
+| `g6R.preserve_elements_position` | `FALSE` | Preserve node positions across redraws instead of recomputing them. |
+
 ## User Interface Elements
 
 ### Keyboard Shortcuts


### PR DESCRIPTION
## What

Render the DAG with G6's default **canvas** renderer in production instead of the forced SVG renderer. SVG stays available for tests via a new `blockr.dag.svg_renderer` option.

## Why

The SVG renderer was forced only so `shinytest2` e2e tests could query/screenshot elements in the DOM. But `@antv/g`'s SVG element reports `offsetWidth == 0`, so `g-lite`'s `getScale()` (`bbox.width / offsetWidth`) falls back to scale `1` and the client/canvas coordinate mapping ignores the page zoom factor. Below 100% browser zoom that desyncs hit-testing, so create-edge drops and port grabs silently fail. The canvas renderer has a real `offsetWidth`, so zoom works.

## How

- `set_g6_options()` selects the renderer via `use_svg_renderer()`: canvas by default, SVG when `getOption("blockr.dag.svg_renderer")` is `TRUE`.
- `tests/testthat/test-e2e.R` opts into SVG with `AppDriver$new(options = list(blockr.dag.svg_renderer = TRUE))`, so DOM-based e2e assertions are unchanged.
- Documented the option on `?new_dag_extension` and in the `blockr.dag` vignette (new Options section, also covering the g6R options the package uses).

## Dependency

Requires `g6R (>= 0.6.0.9001)`: under canvas, the create-edge assist node would otherwise crash the image loader (`Cannot read properties of undefined (reading 'src')`). Fixed in g6R by giving the hidden assist node a transparent `src`.

## Verification

Confirmed via headless chromote that the default is canvas and the option flips it to SVG (elements back in the DOM). The create-edge gesture starts cleanly under canvas with no exceptions. The end-user 80%-zoom drop still warrants a real-mouse check.