### PR TITLE
Fix #144: preserve NULL block state across copy/paste

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,6 +47,8 @@ Suggests:
     quarto,
     cyclocomp,
     shinytest2,
+    chromote,
+    withr,
     colorspace
 Config/testthat/edition: 3
 URL: https://bristolmyerssquibb.github.io/blockr.dag/

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Fix [#86](https://github.com/BristolMyersSquibb/blockr.dag/issues/86).
 - Fix [#110](https://github.com/BristolMyersSquibb/blockr.dag/issues/110): copy/cut keyboard shortcuts no longer hijack plain text selections (column names, error messages, etc.).
 - Fix [#123](https://github.com/BristolMyersSquibb/blockr.dag/issues/123): renaming a block now relabels its DAG node instead of erroring. `update_observer()` handed blockr.core's partial-argument `blocks$mod` delta straight to `update_nodes()` (which needs full `block` objects); it now updates the node label directly from the delta.
+- Fix [#144](https://github.com/BristolMyersSquibb/blockr.dag/issues/144): copy/paste no longer corrupts `NULL`-valued block state. `copy_selection_to_clipboard()` serialized the clipboard with `toJSON()`'s default `null = "list"`, encoding `NULL` as `{}` and deserializing it back into `list()`; pasted blocks then errored on first data (e.g. `nzchar(list())` -> "argument is of length zero" in the chart and table blocks). Now passes `null = "null"` to match blockr.core's save/restore serialization, round-tripping `NULL` faithfully.
 
 # blockr.dag 0.1.0
 

--- a/R/action.R
+++ b/R/action.R
@@ -100,7 +100,8 @@ copy_selection_to_clipboard <- function(board, dag_extension) {
   json <- tryCatch(
     as.character(jsonlite::toJSON(
       blockr_ser(subboard, blocks = states),
-      auto_unbox = TRUE
+      auto_unbox = TRUE,
+      null = "null"
     )),
     error = function(e) {
       showNotification(

--- a/tests/testthat/setup-chrome-ci.R
+++ b/tests/testthat/setup-chrome-ci.R
@@ -1,0 +1,44 @@
+# CI hardening for the chromote-driven shinytest2 e2e tests.
+
+# Give Chrome longer to open its remote-debugging port. chromote's default is
+# 10s (`getOption("chromote.timeout", 10)` in launch_chrome_impl), too short on
+# loaded CI runners -- Windows especially -- where launch intermittently aborts
+# with "Chrome debugging port not open after 10 seconds". Scoped to the suite
+# so the option is restored when testing finishes.
+withr::local_options(
+  chromote.timeout = 30,
+  .local_envir = testthat::teardown_env()
+)
+
+# Chrome leaves scratch dirs (com.google.Chrome.* / org.chromium.Chromium.*,
+# scoped_dir variants included) in the session temp parent (`$TMPDIR`), which
+# R CMD check then flags as "detritus in the temp directory" -- a NOTE the CI
+# gate fails on. `app$stop()` only ends the shinytest2 session; the shared
+# browser stays alive until R exits, so its scratch is never reclaimed. At the
+# end of the suite, close the browser (a clean shutdown reclaims its scratch),
+# then sweep anything that still leaked -- but only what this run created, so a
+# shared `$TMPDIR` on a developer machine keeps its other dirs.
+local({
+
+  pat <- "^(com\\.google\\.Chrome|org\\.chromium\\.Chromium)"
+  tmp_parent <- dirname(tempdir())
+  before <- list.files(tmp_parent, pattern = pat)
+
+  withr::defer(
+    {
+      if (isTRUE(chromote::has_default_chromote_object())) {
+        try(chromote::default_chromote_object()$close(), silent = TRUE)
+      }
+
+      unlink(
+        file.path(
+          tmp_parent,
+          setdiff(list.files(tmp_parent, pattern = pat), before)
+        ),
+        recursive = TRUE,
+        force = TRUE
+      )
+    },
+    testthat::teardown_env()
+  )
+})


### PR DESCRIPTION
## Problem

`copy_selection_to_clipboard()` serialized the clipboard payload with `jsonlite::toJSON()`'s default `null = "list"`, which encodes an R `NULL` as an empty JSON object `{}` and deserializes it back into `list()` rather than `NULL`.

Pasted blocks then held `list()` where their constructors expected `NULL`, and errored on first data — e.g. `nzchar(list())` raises "argument is of length zero" in the chart and table blocks. The chart block hits this regularly because it has ~30 `NULL`-defaulting state args.

Root cause is the DAG clipboard serialization, not the individual blocks.

## Fix

Pass `null = "null"` to the `toJSON()` call in `copy_selection_to_clipboard()` (`R/action.R`), so `NULL` round-trips faithfully. This matches the serialization blockr.core already uses in its save/restore path (`write_json()` in `plugin-serdes.R`), which is why save/restore was always correct and only copy/paste was broken.

The change is decode-safe: blockr.core's restore already turns JSON `null` back into R `NULL`, so no decode-side change is needed.

Closes #144