### PR TITLE
Drop the "(copy)" suffix from pasted blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The node status badge reflects a block's full eval status, not just error conditions ([#145](https://github.com/BristolMyersSquibb/blockr.dag/issues/145)). The badge is derived by `blockr.dock::block_status_badge()` -- the single derivation the dock card icon and the DAG node badge share -- so a node shows the same amber `waiting`, yellow `unset` or red `failed` dot as the dock, with identical colour and geometry. Any error condition still shows red (a render-phase error leaves a block `ready` but errored). A `ready` node carries no badge; a `dormant` node -- one whose status is not currently computed because nothing renders its output -- keeps its last-known badge rather than dropping it, so every invalid block stays flagged even after it leaves the eval set.
 
+- Pasted blocks keep their original names; the `" (copy)"` suffix is gone from blocks. A pasted group is offset on the canvas and selected, so the label carried no extra information, and mass-renaming made copying larger app parts painful. Stacks keep the suffix (`Cohort (copy)`) as group-level provenance.
+
 - Node positions are externally controllable ([#120](https://github.com/BristolMyersSquibb/blockr.dag/issues/120)). The `positions` handle is registered via `external_ctrl`, so positions can be set programmatically (e.g. by an AI assistant) through the board update lifecycle: `update(list(extensions = list(mod = list(<ext_id> = list(positions = list(<block-id> = list(x = , y = )))))))` moves the corresponding nodes. The handle is bidirectional: it tracks live user drags (debounced) and pushes external writes to the client, with a whole-pixel-rounded equality guard that prevents the set/echo feedback loop.
 
 ## Internal changes

--- a/R/subboard.R
+++ b/R/subboard.R
@@ -116,13 +116,13 @@ live_block_states <- function(board, block_ids) {
 
 # --- ID remapping helpers ---
 
+# Block names are kept as-is on paste: a pasted group is offset on the canvas
+# and selected, so a " (copy)" suffix carries no extra provenance, while the
+# mass-renaming makes large copies painful. Stacks keep the suffix for
+# group-level provenance (see remap_stacks()).
 remap_blocks <- function(blocks, id_map) {
   blk_list <- as.list(blocks)
   names(blk_list) <- id_map[names(blk_list)]
-  blk_list <- lapply(blk_list, function(blk) {
-    block_name(blk) <- paste0(block_name(blk), " (copy)")
-    blk
-  })
   as_blocks(blk_list)
 }
 

--- a/tests/testthat/test-subboard.R
+++ b/tests/testthat/test-subboard.R
@@ -197,20 +197,16 @@ test_that("empty subboard round-trips", {
 
 # --- remap_blocks() ---
 
-test_that("remap_blocks() remaps IDs and adds (copy) suffix", {
+test_that("remap_blocks() remaps IDs and keeps block names as-is", {
   sb <- extract_subboard(test_board, block_ids = c("a", "b"))
   id_map <- c(a = "x1", b = "x2")
 
   remapped <- remap_blocks(sb$blocks, id_map)
   expect_named(remapped, c("x1", "x2"))
-  expect_true(all(grepl(
-    "\\(copy\\)$",
-    vapply(
-      as.list(remapped),
-      block_name,
-      character(1)
-    )
-  )))
+  expect_identical(
+    vapply(as.list(remapped), block_name, character(1), USE.NAMES = FALSE),
+    vapply(as.list(sb$blocks), block_name, character(1), USE.NAMES = FALSE)
+  )
 })
 
 # --- remap_links() ---
@@ -278,12 +274,18 @@ test_that("remap_subboard_ids() preserves counts", {
   expect_length(remapped$stacks, length(sb$stacks))
 })
 
-test_that("remap_subboard_ids() adds (copy) suffix to block names", {
+test_that("remap_subboard_ids() keeps block names, suffixes stack names", {
   sb <- extract_subboard(test_board, block_ids = c("a", "b"))
   remapped <- remap_subboard_ids(sb, test_board)
 
   nms <- vapply(as.list(remapped$blocks), block_name, character(1))
-  expect_true(all(grepl("\\(copy\\)$", nms)))
+  expect_identical(
+    unname(nms),
+    unname(vapply(as.list(sb$blocks), block_name, character(1)))
+  )
+
+  stk_nms <- vapply(as.list(remapped$stacks), stack_name, character(1))
+  expect_true(all(grepl("\\(copy\\)$", stk_nms)))
 })
 
 test_that("remap_subboard_ids() links reference new block IDs", {


### PR DESCRIPTION
Pasting appended " (copy)" to every block name, which makes copying larger parts of an app painful: each pasted block then needs a manual rename. The suffix carries little information at paste time anyway; the pasted group is offset on the canvas and selected.

Change: `remap_blocks()` keeps block names verbatim (the rename `lapply` is deleted). Stacks keep the " (copy)" suffix, so a copied stack (`Cohort (copy)`) still provides group-level provenance at zero per-block cost.

Tests pin the new contract: block names preserved on `remap_blocks()` / `remap_subboard_ids()`, stack suffix still asserted.

Trade-off accepted here: blocks pasted within the same board are name-identical to their originals once deselected. If that ever needs revisiting, suffixing only single-block pastes can be layered on top without reshaping this diff.