### PR TITLE
Retarget shinytest2 pin from nbenn fork to rstudio upstream

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Remotes:
     BristolMyersSquibb/blockr.dock,
     BristolMyersSquibb/blockr.ui,
     cynkra/g6R,
-    nbenn/shinytest2@wait-for-app-serving
+    rstudio/shinytest2
 Suggests:
     knitr,
     rmarkdown,


### PR DESCRIPTION
## Summary

- Retarget the shinytest2 `Remotes:` pin from `nbenn/shinytest2@wait-for-app-serving` (a personal fork) to canonical `rstudio/shinytest2`.
- The port-binding fix that fork carried landed upstream in rstudio/shinytest2#448 (merged via #449), plus the follow-up Windows-timeout CI fixes (#450) — upstream `main` is a strict superset of the fork branch, and the DAG counterpart of the flake tracked here.
- The fix isn't in a CRAN release yet, so the pin stays; this changes only *which* source it resolves from. `pak` resolution verified clean (dag's own direct pin wins — dock's Suggests-only remote is never pulled into a conflict).
- Coordinated with BristolMyersSquibb/blockr.dock#310; the two PRs are independent (no merge-order constraint). The pin comes out once the fix reaches CRAN. Keeping #148 open until then.

Refs #148